### PR TITLE
Analytics Improvment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "iojs-v3.x"
+  - "iojs-v3.3.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "iojs-v3.x"

--- a/config/sample.yml
+++ b/config/sample.yml
@@ -8,3 +8,6 @@ ports:
   secure: 443
   unsecure: 80
 hostname: yoursecondphone.co
+
+# for @analytics, optional
+amplitude_public_api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/public/static/js/src/ysp-controllers.js
+++ b/public/static/js/src/ysp-controllers.js
@@ -5,7 +5,6 @@
   global $
   global _
   global angular
-  global async
   */
 
   angular.module('ysp-controllers', ['ngSanitize'])

--- a/public/static/js/src/ysp-services.js
+++ b/public/static/js/src/ysp-services.js
@@ -12,6 +12,12 @@
 
   angular.module('ysp-services', [])
 
+  .service('_amp', [function amplitude_analytics_svc () {
+    this.logEvent = function (_eve, data, done) {
+      return _.get(global, 'amplitude.logEvent', angular.noop).call(_.get(global, 'amplitude'), _eve, data, done)
+    }
+  }])
+
   /*
 
 oo.ooooo.   .ooooo.   .ooooo.  oooo d8b

--- a/system/main.js
+++ b/system/main.js
@@ -39,6 +39,9 @@ app.use(function startup (req, res, next) {
     let d = new Date()
     res.locals.current_year = d.getUTCFullYear()
   }
+  if (config.has('amplitude_public_api_key')) {
+    res.locals.amplitude_api_key = config.get('amplitude_public_api_key')
+  }
   next()
 })
 

--- a/system/views/index.jade
+++ b/system/views/index.jade
@@ -51,7 +51,7 @@ block js
 	if !!amplitude_api_key
 		script(type="text/javascript").
 			(function(e,t){var r=e.amplitude||{};var n=t.createElement("script");n.type="text/javascript";
-			n.async=true;n.src="https://d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.4.0.js";
+			n.async=true;n.src="https://d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.4.0-min.gz.js";
 			var s=t.getElementsByTagName("script")[0];s.parentNode.insertBefore(n,s);r._q=[];function a(e){
 			r[e]=function(){r._q.push([e].concat(Array.prototype.slice.call(arguments,0)))}}var i=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties"];
 			for(var o=0;o<i.length;o++){a(i[o])}e.amplitude=r})(window,document);

--- a/system/views/index.jade
+++ b/system/views/index.jade
@@ -47,3 +47,14 @@ block js
 	//- script(src="/static/js/src/ysp-services.js")
 	//- script(src="/static/js/src/ysp-main.js")
 	script(src="/static/js/build/ysp.js")
+	
+	if !!amplitude_api_key
+		script(type="text/javascript").
+			(function(e,t){var r=e.amplitude||{};var n=t.createElement("script");n.type="text/javascript";
+			n.async=true;n.src="https://d24n15hnbwhuhn.cloudfront.net/libs/amplitude-2.4.0.js";
+			var s=t.getElementsByTagName("script")[0];s.parentNode.insertBefore(n,s);r._q=[];function a(e){
+			r[e]=function(){r._q.push([e].concat(Array.prototype.slice.call(arguments,0)))}}var i=["init","logEvent","logRevenue","setUserId","setUserProperties","setOptOut","setVersionName","setDomain","setDeviceId","setGlobalUserProperties"];
+			for(var o=0;o<i.length;o++){a(i[o])}e.amplitude=r})(window,document);
+
+			amplitude.init('#{amplitude_api_key}');
+			amplitude.setOptOut(_.get(window, 'navigator.doNotTrack', '0') === '1')


### PR DESCRIPTION
Use [amplitude](https://amplitude.com/) to track events. If you are viewing this PR in the future. Here is a tip: to view all the parts of the app that have analytics in them, grep search for `@analytics`. All analytics snippets are marked with that annotation. no sneakiness!

Also, very important. The new amplitude tracking will respect the **do not track** setting that modern browsers send. So if you check that option in your browser, not a single bit of tracking will be done by amplitude!

So, no fear! The privacy-respecting video-chat app you love so much is still privacy-respecting! 😃